### PR TITLE
fix: added null object assertion - fixes #16

### DIFF
--- a/src/lib/clone.js
+++ b/src/lib/clone.js
@@ -3,7 +3,7 @@
 'use strict';
 
 let clone = (obj, parent) => {
-    if (typeof obj !== 'object') {
+    if (typeof obj !== 'object' || obj === null) {
         return obj;
     }
     let cloned = new obj.constructor();


### PR DESCRIPTION
This fixes issue #16.

The issue actually is caused by the recent update of https://github.com/ben-eb/postcss-discard-comments/commit/fe24848c3c58b283f10d4f61cec206557b543e31, specifically the change of `delete node.raws.value` to `node.raws.value = null` (src/index.js). 
Since `typeof null` is equivalent to `'object'` and the null object has no constructor method, this must be checked before proceeding.