### PR TITLE
Speedups

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,13 +35,13 @@ function sameParent (ruleA, ruleB) {
     return hasParent ? sameType : true;
 }
 
-function canMerge (ruleA, ruleB, browsers) {
+function canMerge (ruleA, ruleB, browsers, compatibilityCache) {
     const a = ruleA.selectors;
     const b = ruleB.selectors;
 
     const selectors = a.concat(b);
 
-    if (!ensureCompatibility(selectors, browsers)) {
+    if (!ensureCompatibility(selectors, browsers, compatibilityCache)) {
         return false;
     }
 
@@ -158,12 +158,12 @@ function partialMerge (first, second) {
     }
 }
 
-function selectorMerger (browsers) {
+function selectorMerger (browsers, compatibilityCache) {
     let cache = null;
     return function (rule) {
         // Prime the cache with the first rule, or alternately ensure that it is
         // safe to merge both declarations before continuing
-        if (!cache || !canMerge(rule, cache, browsers)) {
+        if (!cache || !canMerge(rule, cache, browsers, compatibilityCache)) {
             cache = rule;
             return;
         }
@@ -208,6 +208,7 @@ export default postcss.plugin('postcss-merge-rules', () => {
             path: opts && opts.from,
             env: opts && opts.env,
         });
-        css.walkRules(selectorMerger(browsers));
+        const compatibilityCache = {};
+        css.walkRules(selectorMerger(browsers, compatibilityCache));
     };
 });

--- a/src/lib/ensureCompatibility.js
+++ b/src/lib/ensureCompatibility.js
@@ -112,6 +112,11 @@ export default function ensureCompatibility (selectors, browsers, compatibilityC
                         compatible = isSupported('css-case-insensitive', browsers);
                     }
                 }
+                if (!compatible) {
+                    // If this node was not compatible,
+                    // break out early from walking the rest
+                    return false;
+                }
             });
         }).process(selector);
         if (compatibilityCache) {

--- a/src/lib/ensureCompatibility.js
+++ b/src/lib/ensureCompatibility.js
@@ -1,6 +1,8 @@
 import {isSupported} from 'caniuse-api';
 import selectorParser from 'postcss-selector-parser';
 
+const simpleSelectorRe = /^#?[-._a-z0-9 ]+$/i;
+
 const cssSel2 = 'css-sel2';
 const cssSel3 = 'css-sel3';
 const cssGencontent = 'css-gencontent';
@@ -64,6 +66,9 @@ export default function ensureCompatibility (selectors, browsers) {
         return false;
     }
     return selectors.every(selector => {
+        if (simpleSelectorRe.test(selector)) {
+            return true;
+        }
         let compatible = true;
         selectorParser(ast => {
             ast.walk(node => {

--- a/src/lib/ensureCompatibility.js
+++ b/src/lib/ensureCompatibility.js
@@ -60,7 +60,7 @@ function isCssMixin (selector) {
     return selector[selector.length - 1] === ':';
 }
 
-export default function ensureCompatibility (selectors, browsers) {
+export default function ensureCompatibility (selectors, browsers, compatibilityCache) {
     // Should not merge mixins
     if (selectors.some(isCssMixin)) {
         return false;
@@ -68,6 +68,9 @@ export default function ensureCompatibility (selectors, browsers) {
     return selectors.every(selector => {
         if (simpleSelectorRe.test(selector)) {
             return true;
+        }
+        if (compatibilityCache && (selector in compatibilityCache)) {
+            return compatibilityCache[selector];
         }
         let compatible = true;
         selectorParser(ast => {
@@ -111,6 +114,9 @@ export default function ensureCompatibility (selectors, browsers) {
                 }
             });
         }).process(selector);
+        if (compatibilityCache) {
+            compatibilityCache[selector] = compatible;
+        }
         return compatible;
     });
 }


### PR DESCRIPTION
I was looking at the flamegraphs for a Gulp/CSS build using cssnano
and it was obvious that a lot of time was spent in `postcss-merge-rules`,
and in particular in `ensureCompatibility`.

This PR optimizes `ensureCompatibility` by:

* making it skip all compatibility checking for very simple selectors (selectors that should be supported by all browsers anyway)
* stopping the selector tree walk as soon as we realize the selector is not going to be compatible
* caching the results of the rule compatibility checks

# Performance impact

I used this script to run my CSS build 10 times, then print out the cumulative wallclock time.

```bash
#!/bin/bash
set -e
TIMEFORMAT=time=%3R
echo -n $1 ": "
(for i in $(seq 1 10); do time node ./node_modules/.bin/gulp css; done) 2>&1 | grep ^time= | gawk -F= 'BEGIN{ORS=" "}{sum+=$2;print $2;} END {print "total", sum;}'
```

The results are

```
master: 7.579 5.657 5.383 5.096 5.028 4.913 5.057 4.959 4.892 5.238 total 53.802 
speedup: 3.918 4.048 3.985 4.025 4.014 4.011 3.869 3.883 3.938 3.902 total 39.593 
```

so just using this branch results in a **26% speed increase.**