### PR TITLE
Do not merge single-colon and double-colon syntax for pseudo-elements

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -257,6 +257,12 @@ test(
 );
 
 test(
+    'should not merge single-colon and double-colon syntax for pseudo-elements',
+    testOutput,
+    'code :-ms-input-placeholder{color:red}code ::-ms-input-placeholder{color:red}'
+);
+
+test(
     'should merge text-* properties',
     testOutput,
     'h1{color:red;text-align:right;text-decoration:underline}h2{text-align:right;text-decoration:underline}',

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,11 @@ function sameVendor (selectorsA, selectorsB) {
     return same(selectorsA) === same(selectorsB);
 }
 
+function sameColons (selectorsA, selectorsB) {
+    let count = selectors => selectors.map(selector => selector.split(':').length - 1).reduce((a, b) => a + b, 0);
+    return count(selectorsA) === count(selectorsB);
+}
+
 const noVendor = selector => !filterPrefixes(selector).length;
 
 function sameParent (ruleA, ruleB) {
@@ -50,7 +55,7 @@ function canMerge (ruleA, ruleB, browsers, compatibilityCache) {
     if (parent && name && ~name.indexOf('keyframes')) {
         return false;
     }
-    return parent && (selectors.every(noVendor) || sameVendor(a, b));
+    return parent && (selectors.every(noVendor) || (sameVendor(a, b) && sameColons(a, b)));
 }
 
 const getDecls = rule => rule.nodes ? rule.nodes.map(String) : [];


### PR DESCRIPTION
IE11 and Edge use different colon syntax for -ms-input-placeholder. When such rules are merged, IE11 does not apply the rule.
``` .c-input-text:-ms-input-placeholder {
  color: red;
}
.c-input-text::-ms-input-placeholder {
  color: red;
}```
was merged to:
```.c-input-text:-ms-input-placeholder,.c-input-text::-ms-input-placeholder {
  color: #b44b45;
}```